### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/alimatoladosu0340/37e44cf6-d24c-44a2-adac-72f1e5f59196/337d9018-1844-4194-8451-00777be71581/_apis/work/boardbadge/ae8f7576-1b5a-4801-ba1a-4fb5250e3122)](https://dev.azure.com/alimatoladosu0340/37e44cf6-d24c-44a2-adac-72f1e5f59196/_boards/board/t/337d9018-1844-4194-8451-00777be71581/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/alimatoladosu0340/37e44cf6-d24c-44a2-adac-72f1e5f59196/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.